### PR TITLE
Delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As of [motion-cocoapods](https://github.com/HipByte/motion-cocoapods/compare/1.3
 To create a slide menu in your application, you need to start in your AppDelegate:
 
 ```ruby
-class AppDelegate < ProMotion::AppDelegateParent
+class AppDelegate < PM::Delegate
 
   def on_load(app, options)
 


### PR DESCRIPTION
Shouldn't this

`class AppDelegate < ProMotion::AppDelegateParent`

be

`class AppDelegate < PM::Delegate`

inside the README...

It was renamed 9months ago https://github.com/clearsightstudio/ProMotion/issues/45

`ProMotion (1.1.2)`
`bubble-wrap (1.4.0)`
`motion-cocoapods (1.4.0)`

If you run it through the old way you get `Terminating app due to uncaught exception 'NameError', reason: 'uninitialized constant ProMotion::AppDelegateParent (NameError)`
