### PR TITLE
Add #gesture_type accesssors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ class AppDelegate < PM::Delegate
     slide_menu.controller(:left).class.name
     # => NavigationScreen
 
+    # To easily change the gestures used to show or hide the drawers
+    slide_menu.gesture_type = :bezel
+    slide_menu.gesture_type
+    # => :bezel
+
     # SlideMenuScreen is just an enhanced subclass of MMDrawerController, so you can do all sorts of things with it
     slide_menu.statusBarViewBackgroundColor = UIColor.redColor
     slide_menu.openDrawerGestureModeMask = MMOpenDrawerGestureModePanningNavigationBar

--- a/lib/pro_motion_slide_menu/gestures.rb
+++ b/lib/pro_motion_slide_menu/gestures.rb
@@ -1,0 +1,52 @@
+module ProMotionSlideMenu
+  module Gestures
+    def gesture_type=(type)
+      self.openDrawerGestureModeMask = gesture_type_from_symbol type, :open
+      self.closeDrawerGestureModeMask = gesture_type_from_symbol type, :close
+    end
+
+    def gesture_type
+      symbol_from_gesture_type self.openDrawerGestureModeMask
+    end
+
+    private
+
+    def gesture_type_from_symbol(symbol, open_or_close)
+      type = open_or_close == :open ? "Open" : "Close"
+
+      case symbol
+      when :nav
+        Object.const_get("MM#{type}DrawerGestureModePanningNavigationBar")
+      when :center
+        Object.const_get("MM#{type}DrawerGestureModePanningCenterView")
+      when :bezel
+        Object.const_get("MM#{type}DrawerGestureModeBezelPanningCenterView")
+      when :custom
+        Object.const_get("MM#{type}DrawerGestureModeCustom")
+      when :all
+        Object.const_get("MM#{type}DrawerGestureModeAll")
+      when :none
+        Object.const_get("MM#{type}DrawerGestureModeNone")
+      else
+        Object.const_get("MM#{type}DrawerGestureModeNone")
+      end
+    end
+
+    def symbol_from_gesture_type(gesture_type)
+      case gesture_type
+      when MMOpenDrawerGestureModePanningNavigationBar, MMCloseDrawerGestureModePanningNavigationBar
+        :nav
+      when MMOpenDrawerGestureModePanningCenterView, MMCloseDrawerGestureModePanningCenterView
+        :center
+      when MMOpenDrawerGestureModeBezelPanningCenterView, MMCloseDrawerGestureModeBezelPanningCenterView
+        :bezel
+      when MMOpenDrawerGestureModeCustom, MMCloseDrawerGestureModeCustom
+        :custom
+      when MMOpenDrawerGestureModeAll, MMCloseDrawerGestureModeAll
+        :all
+      when MMOpenDrawerGestureModeNone, MMCloseDrawerGestureModeNone
+        :none
+      end
+    end
+  end
+end

--- a/lib/pro_motion_slide_menu/slide_menu_screen.rb
+++ b/lib/pro_motion_slide_menu/slide_menu_screen.rb
@@ -2,6 +2,7 @@ module ProMotionSlideMenu
   class SlideMenuScreen < MMDrawerController
 
     include ::ProMotion::ScreenModule
+    include Gestures
 
     #
     # SlideMenuScreen
@@ -15,8 +16,7 @@ module ProMotionSlideMenu
 
       screen = alloc.init
 
-      screen.openDrawerGestureModeMask = MMOpenDrawerGestureModePanningNavigationBar
-      screen.closeDrawerGestureModeMask = MMCloseDrawerGestureModePanningNavigationBar
+      screen.gesture_type = :nav
 
       screen.content_controller = content unless content.nil?
       screen.left_controller = left_vc if left_vc

--- a/spec/slide_menu_gestures_spec.rb
+++ b/spec/slide_menu_gestures_spec.rb
@@ -1,0 +1,32 @@
+describe ProMotionSlideMenu::Gestures do
+
+  before do
+    @delegate = UIApplication.sharedApplication.delegate
+    @screen = ProMotionSlideMenu::SlideMenuScreen.new BlankScreen, left: LeftNavScreen
+  end
+
+  it "defaults to MMOpenDrawerGestureModePanningNavigationBar" do
+    @screen.openDrawerGestureModeMask.should == MMOpenDrawerGestureModePanningNavigationBar
+  end
+
+  describe "#gesture_type=" do
+    before do
+      @screen.gesture_type = :custom
+    end
+
+    it "sets the left mask" do
+      @screen.openDrawerGestureModeMask.should == MMOpenDrawerGestureModeCustom
+    end
+
+    it "sets the right mask" do
+      @screen.closeDrawerGestureModeMask.should == MMCloseDrawerGestureModeCustom
+    end
+  end
+
+  describe "#gesture_type" do
+    it "returns symbol for open" do
+      @screen.openDrawerGestureModeMask = MMCloseDrawerGestureModeCustom
+      @screen.gesture_type.should == :custom
+    end
+  end
+end


### PR DESCRIPTION
Quick accessors for setting the open and close gesture types for the
drawer controller, without using the constants.

``` ruby
# easily set open/close gestures at once
slide_menu.gesture_type = :none
```
