### PR TITLE
fix(drawer): Fix argument error for controller passed to ProMotion

### DIFF
--- a/lib/ProMotion/menu/drawer.rb
+++ b/lib/ProMotion/menu/drawer.rb
@@ -77,6 +77,7 @@ module ProMotion
 
       def prepare_controller_for_pm(controller)
         unless controller.nil?
+          controller = controller.new if controller.respond_to?(:new)
           controller = set_up_screen_for_open(controller, {})
           ensure_wrapper_controller_in_place(controller, {})
           controller.navigationController || controller


### PR DESCRIPTION
Argument error is raised for plain UIViewController and other view controllers
which take no arguments/different number of arguments than screens

see https://github.com/infinitered/ProMotion/commit/d8b7192d759d0dae78998c6a7ce05726f12507a8